### PR TITLE
Let ufw allow ssh by default

### DIFF
--- a/tasks/firewall.yml
+++ b/tasks/firewall.yml
@@ -14,6 +14,7 @@
     rule: allow
     port: "{{ item }}"
   with_items:
+    - 22
     - 25
     - 80
     - 110


### PR DESCRIPTION
I started installing this on my VPS, only to realize that ufw blocked ssh as well, leaving me locked out. Possibly keep port 22 open by default, or maybe warn the user somehow. 